### PR TITLE
scx-scheds: Add options=(!lto), remove glibc as depend, add .SRCINFO

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,20 @@
+pkgbase = scx-scheds
+	pkgdesc = Sched_ext schedulers
+	pkgver = 0.1.1
+	pkgrel = 2
+	url = https://github.com/sched-ext/scx
+	arch = x86_64
+	license = GPL2.0
+	makedepends = meson
+	makedepends = bpf
+	makedepends = pahole
+	makedepends = rust
+	makedepends = cargo
+	depends = libelf
+	depends = zlib
+	depends = libbpf
+	options = !lto
+	source = https://github.com/sched-ext/scx/archive/refs/tags/v0.1.1.tar.gz
+	sha512sums = a917d09cdc4179d0376e26fdee9a5d300442c14e59ce07798785eb8e263978bc90046b6260ebd0d66ee4d0ba3915203683c17c52c29cfad8e9a404b7dde0bd7e
+
+pkgname = scx-scheds

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,14 +2,15 @@
 
 pkgname=scx-scheds
 pkgver=0.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Sched_ext schedulers'
 url='https://github.com/sched-ext/scx'
 arch=('x86_64')
 license=('GPL2.0')
-depends=('glibc' 'libelf' 'zlib' 'libbpf')
-makedepends=('meson' 'bpf' 'pahole' 'rust')
+depends=('libelf' 'zlib' 'libbpf')
+makedepends=('meson' 'bpf' 'pahole' 'rust' 'cargo')
 provides=()
+options=(!lto)
 source=(https://github.com/sched-ext/scx/archive/refs/tags/v${pkgver}.tar.gz)
 sha512sums=('a917d09cdc4179d0376e26fdee9a5d300442c14e59ce07798785eb8e263978bc90046b6260ebd0d66ee4d0ba3915203683c17c52c29cfad8e9a404b7dde0bd7e')
 


### PR DESCRIPTION
Hi,

I have updated the PKGBUILD to follow the archlinux guidelines.
glibc is not required as depend, since it is provided by "base" and "base-devel".

devtools (makechrootpkg) is enabling LTO as default, but the package is not compiling if LTO is enabled, so add options=(!lto).

Add missing .SRCINFO