### PR TITLE
Switch into arch-meson

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=scx-scheds
 pkgver=0.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Sched_ext schedulers'
 url='https://github.com/sched-ext/scx'
 arch=('x86_64')
@@ -16,14 +16,13 @@ sha512sums=('a917d09cdc4179d0376e26fdee9a5d300442c14e59ce07798785eb8e263978bc900
 
 build() {
   cd scx-${pkgver}
-  meson setup build --prefix "${pkgdir}/usr" -Dbuildtype=release
-  cd build
-  meson compile
+  arch-meson . build
+  meson compile -C build
 }
 
 package() {
-  cd scx-${pkgver}/build
-  meson install
+  cd scx-${pkgver}
+  meson install -C build --destdir "${pkgdir}"
 }
 
 # vim: ts=2 sw=2 et:


### PR DESCRIPTION
It might be worth considering using arch-meson, the default solution in Arch Linux. I checked and it seems that everything works as it should. 

```❯ makepkg -sr --sign
==> Making package: scx-scheds 0.1.1-3 (wto, 12 gru 2023, 17:55:28)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Downloading v0.1.1.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  796k    0  796k    0     0   847k      0 --:--:-- --:--:-- --:--:-- 1641k
==> Validating source files with sha512sums...
    v0.1.1.tar.gz ... Passed
==> Extracting sources...
  -> Extracting v0.1.1.tar.gz with bsdtar
==> Starting build()...
+ exec meson setup --prefix /usr --libexecdir lib --sbindir bin --buildtype plain --auto-features enabled --wrap-mode nodownload -D b_lto=true -D b_pie=true -D python.bytecompile=1 . build
The Meson build system
Version: 1.3.0
Source dir: /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1
Build dir: /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/build
Build type: native build
Project name: sched_ext schedulers
Project version: 0.1.1
C compiler for the host machine: cc (gcc 13.2.1 "cc (GCC) 13.2.1 20231110")
C linker for the host machine: cc ld.bfd 2.41.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program clang found: YES (/usr/bin/clang)
Program bpftool found: YES (/usr/bin/bpftool)
Program cargo found: YES (/usr/bin/cargo)
Program /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/get_clang_ver found: YES (/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/get_clang_ver)
Program /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/bpftool_build_skel found: YES (/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/bpftool_build_skel)
Program /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/get_sys_incls found: YES (/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/get_sys_incls)
meson.build:31: WARNING: clang >= 17 recommended (/usr/bin/clang ver=16.0.6)
Found pkg-config: YES (/usr/bin/pkg-config) 2.1.0
Run-time dependency libbpf found: YES 1.2.2
meson.build:45: WARNING: libbpf <1.3 does not support RESIZE_ARRAY(), expect breakages in schedulers that use them
Message: cpu=x86_64 bpf_base_cflags=['-g', '-O2', '-Wall', '-Wno-compare-distinct-pointer-types', '-D__TARGET_ARCH_x86', '-mcpu=v3', '-mlittle-endian', '-idirafter /usr/lib/clang/16/include', '-idirafter /usr/local/include', '-idirafter /usr/include']
Build targets in project: 10

sched_ext schedulers 0.1.1

  User defined options
    auto_features     : enabled
    buildtype         : plain
    libexecdir        : lib
    prefix            : /usr
    sbindir           : bin
    wrap_mode         : nodownload
    python.bytecompile: 1
    b_lto             : true
    b_pie             : true

Found ninja-1.11.1 at /usr/bin/ninja
INFO: autodetecting backend as ninja                                                                                                                                                                                                                                           
INFO: calculating backend command to run: /usr/bin/ninja -C /home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/build
ninja: Entering directory `/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/build'
[9/31] Compiling C object scheds/kernel-examples/scx_central.p/scx_central.c.o
In file included from ../scheds/kernel-examples/scx_central.c:14:
../scheds/kernel-examples/scx_central.c: In function ‘main’:
../scheds/include/scx/common.h:65:38: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   65 |                 skel->elfsec##_##arr =                                            \
      |                                      ^
../scheds/kernel-examples/scx_central.c:73:9: note: in expansion of macro ‘RESIZE_ARRAY’
   73 |         RESIZE_ARRAY(data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
      |         ^~~~~~~~~~~~
../scheds/include/scx/common.h:65:38: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   65 |                 skel->elfsec##_##arr =                                            \
      |                                      ^
../scheds/kernel-examples/scx_central.c:74:9: note: in expansion of macro ‘RESIZE_ARRAY’
   74 |         RESIZE_ARRAY(data, cpu_started_at, skel->rodata->nr_cpu_ids);
      |         ^~~~~~~~~~~~
[16/31] Compiling C object scheds/kernel-examples/scx_pair.p/scx_pair.c.o
In file included from ../scheds/kernel-examples/scx_pair.c:12:
../scheds/kernel-examples/scx_pair.c: In function ‘main’:
../scheds/include/scx/common.h:65:38: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   65 |                 skel->elfsec##_##arr =                                            \
      |                                      ^
../scheds/kernel-examples/scx_pair.c:72:9: note: in expansion of macro ‘RESIZE_ARRAY’
   72 |         RESIZE_ARRAY(rodata, pair_cpu, skel->rodata->nr_cpu_ids);
      |         ^~~~~~~~~~~~
../scheds/include/scx/common.h:65:38: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   65 |                 skel->elfsec##_##arr =                                            \
      |                                      ^
../scheds/kernel-examples/scx_pair.c:73:9: note: in expansion of macro ‘RESIZE_ARRAY’
   73 |         RESIZE_ARRAY(rodata, pair_id, skel->rodata->nr_cpu_ids);
      |         ^~~~~~~~~~~~
../scheds/include/scx/common.h:65:38: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   65 |                 skel->elfsec##_##arr =                                            \
      |                                      ^
../scheds/kernel-examples/scx_pair.c:74:9: note: in expansion of macro ‘RESIZE_ARRAY’
   74 |         RESIZE_ARRAY(rodata, in_pair_idx, skel->rodata->nr_cpu_ids);
      |         ^~~~~~~~~~~~
[31/31] Generating scheds/rust-user/scx_rusty/scx_rusty with a custom command (wrapped by meson to set env)
==> Entering fakeroot environment...
==> Starting package()...
ninja: Entering directory `/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/build'
[3/3] Generating scheds/rust-user/scx_rusty/scx_rusty with a custom command (wrapped by meson to set env)
Installing scheds/kernel-examples/scx_simple to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/kernel-examples/scx_qmap to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/kernel-examples/scx_central to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/kernel-examples/scx_pair to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/kernel-examples/scx_flatcg to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/kernel-examples/scx_userland to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Installing scheds/c-user/scx_nest to /home/lucjan/Pobrane/scx-scheds-packaging-arch/pkg/scx-scheds/usr/bin
Running custom install script '/home/lucjan/Pobrane/scx-scheds-packaging-arch/src/scx-0.1.1/meson-scripts/install_rust_user_scheds'
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> WARNING: Package contains reference to $srcdir
usr/bin/scx_simple
usr/bin/scx_qmap
usr/bin/scx_central
usr/bin/scx_pair
usr/bin/scx_flatcg
usr/bin/scx_userland
usr/bin/scx_nest
usr/bin/scx_layered
usr/bin/scx_rusty
==> Creating package "scx-scheds"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Signing package(s)...
  -> Created signature file scx-scheds-0.1.1-3-x86_64_v3.pkg.tar.zst.sig.
==> Finished making: scx-scheds 0.1.1-3 (wto, 12 gru 2023, 18:23:04)
```