### PR TITLE
auto features meson flags + update makedeps

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -10,7 +10,7 @@ arch=('x86_64')
 url="https://github.com/sched-ext/scx"
 license=('GPL-2.0-only')
 depends=('libelf' 'zlib' 'jq')
-makedepends=('git' 'python' 'meson' 'clang' 'llvm' 'llvm-libs' 'cargo' 'rust')
+makedepends=('git' 'python' 'meson' 'clang' 'llvm' 'llvm-libs' 'rust')
 backup=('etc/default/scx')
 source=("git+https://github.com/sched-ext/scx")
 sha256sums=('SKIP')
@@ -56,7 +56,7 @@ prepare() {
 
 build() {
   cd $gitname
-  arch-meson . build --buildtype release -Dsystemd=enabled -Dopenrc=disabled
+  arch-meson . build --buildtype release --auto-features auto
   meson compile -C build
 }
 


### PR DESCRIPTION
1. Enable autodetection of init system. Upstream changes regarding systemd and OpenRC service files should switch automatically accordingly to the init system in use. #https://github.com/sched-ext/scx/commit/7d335fa1970e9a4a3a8da2dadde9762556eafe87
2. Removed cargo makedep (points to rust itself).

Tested on Artix with OpenRC but needs testing with systemd init system.